### PR TITLE
Working psycopg2 with linux and macos

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,8 +1,7 @@
 load("@io_bazel_rules_docker//python3:image.bzl", "py3_image")
-load("@io_bazel_rules_docker//container:image.bzl")
-load("@pip_deps//:requirements.bzl", "requirement")
-
-
+load("@default_pip_deps//:requirements.bzl", "requirement")
+load("@container_pip_deps//:requirements.bzl", container_requirement = "requirement")
+load("@rules_python//python:defs.bzl", "py_binary")
 
 py_binary(
     name = "demo",
@@ -21,8 +20,8 @@ py3_image(
     srcs = ["demo.py"],
     main = "demo.py",
     deps = [
-        requirement("dbt"),
-        requirement("psycopg2-binary"),
+        container_requirement("dbt"),
+        container_requirement("psycopg2-binary"),
     ],
 )
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ then run pip-compile as shown in the comments at the top of requirements.txt.
 
 # running the docker image locally
 
-    bazel run //:dbt
+    bazel run :demo # no docker, executing with python toolchain on host
+    bazel run :dbt # docker, executing with linux python inside container
 
     # take a look at the configured docker image entrypoints and metadata
     docker inspect bazel:dbt

--- a/demo.py
+++ b/demo.py
@@ -2,9 +2,6 @@
 
 from pprint import pprint
 import sys
-
-pprint(sys.version_info)
-
 import psycopg2
 import dbt.main
 


### PR DESCRIPTION
With this pr, both

    bazel run :demo

and 

    bazel run :dbt

work fine to import psycopg2, which is a python native extension that is very sensitive to the python minor release number. The same code is working against psycopg2 with a macos host using python3.8 and a linux container using python3.7.